### PR TITLE
added support for custom data sources

### DIFF
--- a/grails-app/services/org/codehaus/groovy/grails/plugins/jasper/JasperService.groovy
+++ b/grails-app/services/org/codehaus/groovy/grails/plugins/jasper/JasperService.groovy
@@ -21,6 +21,7 @@
 import java.lang.reflect.Field
 import java.sql.Connection
 
+import net.sf.jasperreports.engine.JRDataSource
 import net.sf.jasperreports.engine.JRExporter
 import net.sf.jasperreports.engine.JRExporterParameter
 import net.sf.jasperreports.engine.JasperCompileManager
@@ -226,15 +227,19 @@ class JasperService {
     private JasperPrint generatePrinter(JasperReportDef reportDef) {
         JasperPrint jasperPrint
         Resource resource = reportDef.getReport()
+        JRDataSource jrDataSource = reportDef.dataSource
 
-        if (reportDef.reportData != null && !reportDef.reportData.isEmpty()) {
-            JRBeanCollectionDataSource jrBeanCollectionDataSource = new JRBeanCollectionDataSource(reportDef.reportData)
+        if (jrDataSource == null && reportDef.reportData != null && !reportDef.reportData.isEmpty()) {
+            jrDataSource = new JRBeanCollectionDataSource(reportDef.reportData)
+        }
+
+        if (jrDataSource != null) {
             if (resource.getFilename().endsWith('.jasper')) {
-                jasperPrint = JasperFillManager.fillReport(resource.inputStream, reportDef.parameters, jrBeanCollectionDataSource)
+                jasperPrint = JasperFillManager.fillReport(resource.inputStream, reportDef.parameters, jrDataSource)
             }
             else {
                 forceTempFolder()
-                jasperPrint = JasperFillManager.fillReport(JasperCompileManager.compileReport(resource.inputStream), reportDef.parameters, jrBeanCollectionDataSource)
+                jasperPrint = JasperFillManager.fillReport(JasperCompileManager.compileReport(resource.inputStream), reportDef.parameters, jrDataSource)
             }
         }
         else {

--- a/src/groovy/org/codehaus/groovy/grails/plugins/jasper/JasperReportDef.groovy
+++ b/src/groovy/org/codehaus/groovy/grails/plugins/jasper/JasperReportDef.groovy
@@ -16,6 +16,7 @@
 
 package org.codehaus.groovy.grails.plugins.jasper
 
+import net.sf.jasperreports.engine.JRDataSource
 import net.sf.jasperreports.engine.JasperPrint
 
 import org.apache.commons.io.FilenameUtils
@@ -52,6 +53,13 @@ class JasperReportDef implements Serializable {
    * This is a list of java beans.
    */
   Collection reportData
+
+  /**
+   * The actual data source used to fill the report.
+   * <p>
+   * This is an implementation of {@link JRDataSource}.
+   */
+  JRDataSource dataSource
 
   /**
    * The target file format.


### PR DESCRIPTION
The existing implementation only allows for Java Bean data sources. If
present, this patch will use a custom data source and fall back to the
existing implementation in all other cases.
