### PR TITLE
Fixes the usage of this plugin by Grails applications that do not have a relational DB data source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ target-eclipse/
 target
 *.log
 *.zip
+*.sha1
 plugin.xml
 /docs/
 .DS_Store

--- a/application.properties
+++ b/application.properties
@@ -1,1 +1,3 @@
-app.grails.version=2.4.4
+#Grails Metadata file
+#Tue Jul 07 16:41:17 AEST 2015
+app.grails.version=2.4.5

--- a/grails-app/services/org/codehaus/groovy/grails/plugins/jasper/JasperService.groovy
+++ b/grails-app/services/org/codehaus/groovy/grails/plugins/jasper/JasperService.groovy
@@ -16,35 +16,27 @@
 
  package org.codehaus.groovy.grails.plugins.jasper
 
- import groovy.sql.Sql
-
-import java.lang.reflect.Field
-import java.sql.Connection
-
-import net.sf.jasperreports.engine.JRDataSource
-import net.sf.jasperreports.engine.JRExporter
-import net.sf.jasperreports.engine.JRExporterParameter
-import net.sf.jasperreports.engine.JasperCompileManager
-import net.sf.jasperreports.engine.JasperFillManager
-import net.sf.jasperreports.engine.JasperPrint
+import groovy.sql.Sql
+import net.sf.jasperreports.engine.*
 import net.sf.jasperreports.engine.data.JRBeanCollectionDataSource
 import net.sf.jasperreports.engine.export.JRHtmlExporterParameter
 import net.sf.jasperreports.engine.export.JRTextExporterParameter
 import net.sf.jasperreports.engine.export.JRXlsExporterParameter
 import net.sf.jasperreports.engine.util.JRProperties
-
 import org.springframework.core.io.Resource
-import org.springframework.transaction.annotation.Transactional
+
+import java.lang.reflect.Field
+import java.sql.Connection
 
 /**
  * Generates Jasper reports. Call one of the three generateReport methods to
  * get a ByteArrayOutputStream with the generated report.
  * @author Sebastian Hohns
  */
-@Transactional(readOnly = true)
 class JasperService {
 
     def dataSource
+    def transactional = false
 
     static final boolean FORCE_TEMP_FOLDER = false
 


### PR DESCRIPTION
Eg: front-end app that only uses web services to access data

When no datasource is present in the DataSource.groovy file, a transaction manager is not created and therefore the services with a @Transaction annotation fail at runtime
It is the same scenario as the one described in this stackoverflow entry: http://stackoverflow.com/questions/10296382/developing-grails-plugin-no-bean-named-transactionmanager-is-defined-in-inte
Regardless of this error, since all the DB operations performed to generate a report are read-only, a transaction is not required.
Cheers
